### PR TITLE
Remove files from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
   "files": [
     "docs",
     "dist",
-    "conf"
+    "conf",
+    "lib",
+    "app.js",
+    "index.js"
   ],
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
when attempting to install package via npm, the lib directory is not included. 

package.json
```
"dependencies": {
    "appc.jwplayer": "git+https://git@github.com/appcelerator-archive/appc.jwplayer.git",
...
```
